### PR TITLE
Changes to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ npm install
 npm install --global expo-cli
 expo start
 ```
+
+If the tab icons fail to load, try running expo with the Metro bundler cache cleared.
+
+`expo start -c`


### PR DESCRIPTION
For people who had previously ran the frontend using expo, attempting to start up the frontend after the implementation of icons can result in error messages. The fix is to clear the Metro bundler cache when starting expo:

`expo start -c`

I added this fix to the README.md