### PR TITLE
Added node_modules/ to root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 desktop.ini
+
+node_modules/


### PR DESCRIPTION
Prevents node_modules/ folder in backend/ from showing up as untracked when switching to the frontend branches