### PR TITLE
Rerenders the Data tab on blur

### DIFF
--- a/frontend/App.jsx
+++ b/frontend/App.jsx
@@ -44,7 +44,7 @@ function HomeTabs() {
     >
       {/* The different tabs routes are declared here as Screens */}
       <Tab.Screen name="Diagnostics" component={DiagnosticsTab} />
-      <Tab.Screen name="Data" component={DataTab} />
+      <Tab.Screen name="Data" component={DataTab} options = {{ unmountOnBlur: true }} />
       <Tab.Screen name="Home" component={HomeTab} />
       <Tab.Screen name="Ambiance" component={AmbianceTab} />
       <Tab.Screen name="Settings" component={SettingsTab} />

--- a/frontend/App.jsx
+++ b/frontend/App.jsx
@@ -44,7 +44,7 @@ function HomeTabs() {
     >
       {/* The different tabs routes are declared here as Screens */}
       <Tab.Screen name="Diagnostics" component={DiagnosticsTab} />
-      <Tab.Screen name="Data" component={DataTab} options = {{ unmountOnBlur: true }} />
+      <Tab.Screen name="Data" component={DataTab} options={{ unmountOnBlur: true }} />
       <Tab.Screen name="Home" component={HomeTab} />
       <Tab.Screen name="Ambiance" component={AmbianceTab} />
       <Tab.Screen name="Settings" component={SettingsTab} />


### PR DESCRIPTION
This is a UX decision. Currently, when you navigate into a Detailed Data page by clicking on one of the items in the FlatList in the Data tab, and then navigate to a different tab and back, the Data tab will still show the Detailed Data page you were on. Merging this pull request will make it so that navigating out of and back into the Data tab will reset the tab to show the initial loading screen, which is all of the items in the FlatList.

I'm not sure how well I explained that but you can see it in the app by pulling this branch and running the app using this branch. And you can switch back and forth between this branch and frontend to see the difference.

Note: This same redesign can be applied to the Settings tab as well.

@williamchong256 Don't merge