### PR TITLE
Use styled-components/native

### DIFF
--- a/frontend/Themes.js
+++ b/frontend/Themes.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/native';
 
 const BodyText = styled.Text`
     font-weight: 300;


### PR DESCRIPTION
Use styled-components/native instead of styled-components per Expo documentation

https://docs.expo.io/guides/using-styled-components/