### PR TITLE
Set the header of each detailed data page to its date

### DIFF
--- a/frontend/detailedData.jsx
+++ b/frontend/detailedData.jsx
@@ -6,9 +6,16 @@ import {
   BodyText, DataView, DataPointView, PageTitle, Subheading,
 } from './Themes';
 
-function DetailedData({ route }) {
+function DetailedData({ navigation, route }) {
   // Retrieve our item in route.params
   const { item } = route.params;
+
+  React.useLayoutEffect(() => {
+    navigation.setOptions({
+      title: item.key,
+    });
+  }, [navigation]);
+
   return (
   // Simple example of displaying data based in route
 


### PR DESCRIPTION
Currently the header of each detailed data page just says "DetailedData". This PR makes it so the header of each detailed data page is the date of the page.

Closes #55 